### PR TITLE
Correct and simplify python setup instructions.

### DIFF
--- a/Python/PythonInstall/PythonInstall.Rmd
+++ b/Python/PythonInstall/PythonInstall.Rmd
@@ -65,7 +65,7 @@ The Anaconda Python distribution is designed with data Science in mind and conta
 
 ![](Python/PythonInstall/images/Anaconda_navigator.png)
 
-To check that the installation is working correctly, click the `Launch` button under `Jupyter Notebook`. A new blank notebook should be created.
+To check that the installation is working correctly, click the `Launch` button under `JupyterLab`. A JupyterLab window should open in your web browser.
 
 <div class="alert alert-danger">
 **If you are having any difficulties with the installation, please stop by the training room 20 minutes prior to the start of the workshop.**
@@ -74,12 +74,12 @@ To check that the installation is working correctly, click the `Launch` button u
 
 ## Jupyter notebook interfaces
 
-We will be using Jupyter Notebooks to run our Python code. Notebooks are web-based applications that allow you to create and share documents that contain live code, equations, visualizations, and narrative text. There are two main ways to interact with Jupyter Notebooks:
+We will be using Jupyter Notebooks to run our Python code. [Jupyter Notebooks](https://jupyter-notebook.readthedocs.io/en/stable/) are documents that combine text, code, images, math, and rich media and can be viewed in a browser. There are two main ways to interact with Jupyter Notebooks:
 
-1. using **JupyterLab**
-2. opening a **Jupyter Notebook** directly in a browser
+1. using **JupyterLab**, a modern "extensible environment for interactive and reproducible computing" that runs in your web browser.
+2. using **Jupyter Notebook**, and older browser-based application.
 
-[Jupyter Notebooks](https://jupyter-notebook.readthedocs.io/en/stable/) are documents that combine text, code, images, math, and rich media and can be viewed in a browser. Opening a notebook directly in a browser lets you read and write to the file, but does not give you access to any other files in the same folder (e.g., data or images) unless these are manually uploaded using the browser. You also do not have access to features typically found on integrated development environments (IDEs). [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/), in contrast, is an interface for Jupyter Notebooks that is a way to access notebooks within a web-based IDE. Among other things, this allows easy access to data files and media associated with the notebook without having to manually upload these using a browser. For this reason, **we strongly recommend that you use JupyterLab to interact with notebooks**.
+Compared to Jupyter Notebook,  JupyterLab provides a more modern, richer and more robust coding environment. For this reason, **we strongly recommend that you use JupyterLab to interact with notebooks**.
 
 
 ### Launch JupyterLab
@@ -87,29 +87,11 @@ We will be using Jupyter Notebooks to run our Python code. Notebooks are web-bas
 Here's how to start JupyterLab and open a notebook within this interface (**recommended**):
 
 1. Start the `Anaconda Navigator` program
-2. Click the `Launch` button under `Jupyter Lab`
+2. Click the `Launch` button under `JupyterLab`
 3. A browser window will open with your computer's files listed on the left hand side of the page. Navigate to the folder with the workshop materials that you downloaded to your desktop and double-click on the folder
-4. Within the workshop materials folder, double-click on the file with the word "BLANK" in the name (`*_BLANK.ipynb`). A pop-up window will ask you to `Select Kernal` --- you should select the Python 3 kernal. The Jupyter Notebook should now open on the right hand side of the page
+4. Within the workshop materials folder, double-click on the file with the word "BLANK" in the name (`*_BLANK.ipynb`). (If a pop-up window asks you to `Select Kernel` choose `Python 3` kernel.) The Jupyter Notebook should now open on the right hand side of the page.
 
-
-### Launch Jupyter Notebook
-
-Here's how to start a Jupyter Notebook directly in a browser (**NOT** recommended unless JupyterLab doesn't work on your machine):
-
-1. Start the `Anaconda Navigator` program
-2. Click the `Launch` button under `Jupyter Notebook`
-3. Create a new folder (by default called `Untitled Folder`) by clicking the drop down menu called `New` on the top right of the page
-4. Navigate to the new `Untitled Folder` and check the box next to it. Then click the `Rename` button on the top left of the page and name the folder with the workshop name (e.g., `PythonIntro`)
-5. Click on the folder you just created. From within the folder, click `Upload` in the top right of the page. A pop-up window will open; use it to navigate to the workshop materials folder on your desktop. Select and open all the files in the top level of the folder (e.g., `PythonIntro_BLANK.ipynb`, `PythonIntro.ipynb`, `Alice_in_wonderland.txt`, and `Characters.txt`)
-6. Click the blue colored `Upload` button to upload the files to the `PythonIntro` folder on your browser
-
-Optionally, to view images inline you can additionally complete these steps:
-
-7. Within the `PythonIntro` folder on your browser, create a new folder (by default called `Untitled Folder`) by clicking the drop down menu called `New` on the top right of the page
-8. Navigate to the new `Untitled Folder` and check the box next to it. Then click the `Rename` button on the top left of the page and name the folder with the name `images`
-9. Click on the folder you just created. From within the folder, click `Upload` in the top right of the page. A pop-up window will open; use it to navigate to the workshop materials folder on your desktop. Within that folder, click on the `images` folder. Select and open all the files within the `images` folder (e.g., `name_of_image.png`)
-10. Click the blue colored `Upload` button to upload the files to the `images` folder within the workshop materials folder on your browser
-
+If you have technical difficulty with JupyterLab you can try the older Jupyter Notebook as a fallback by clicking the `Launch` button under `Jupyter Notebook` in step 2.
 
 ## Resources
 


### PR DESCRIPTION
These changes remove misleading descriptions of Jupyter Notebooks and simplifies the Python installation instructions. I didn't update/rebuild the bookdown website since I'm not sure what the procedure for doing that is these days.