### PR TITLE
Remove extra sed arguments and make statapath work on linux

### DIFF
--- a/Stata/StataDatMan/StataDatMan.Rmd
+++ b/Stata/StataDatMan/StataDatMan.Rmd
@@ -2,7 +2,9 @@
 ```{r, echo=FALSE, results=FALSE, eval=TRUE}
 require(knitr)
 knitr::opts_chunk$set(eval=FALSE, results=FALSE, message=FALSE, warning=FALSE, error=FALSE)
-statapath <- "/Applications/Stata/StataMP.app/Contents/MacOS/stata-mp"
+os <- Sys.info()["sysname"]
+if(os == "Darwin") statapath <- "/Applications/Stata/StataMP.app/Contents/MacOS/stata-mp"
+if(os == "Linux") statapath <- system("which stata-mp", intern = TRUE)
 opts_chunk$set(engine="stata", engine.path=statapath, comment="")
 ```
 

--- a/Stata/StataIntro/StataIntro.Rmd
+++ b/Stata/StataIntro/StataIntro.Rmd
@@ -2,7 +2,9 @@
 ```{r, echo=FALSE, results=FALSE, eval=TRUE}
 require(knitr)
 knitr::opts_chunk$set(eval=FALSE, results=FALSE, message=FALSE, warning=FALSE, error=FALSE)
-statapath <- "/Applications/Stata/StataMP.app/Contents/MacOS/stata-mp"
+os <- Sys.info()["sysname"]
+if(os == "Darwin") statapath <- "/Applications/Stata/StataMP.app/Contents/MacOS/stata-mp"
+if(os == "Linux") statapath <- system("which stata-mp", intern = TRUE)
 opts_chunk$set(engine="stata", engine.path=statapath, comment="")
 ```
 

--- a/Stata/StataModGraph/StataModGraph.Rmd
+++ b/Stata/StataModGraph/StataModGraph.Rmd
@@ -2,7 +2,9 @@
 ```{r, echo=FALSE, results=FALSE, eval=TRUE}
 require(knitr)
 knitr::opts_chunk$set(eval=FALSE, results=FALSE, message=FALSE, warning=FALSE, error=FALSE)
-statapath <- "/Applications/Stata/StataMP.app/Contents/MacOS/stata-mp"
+os <- Sys.info()["sysname"]
+if(os == "Darwin") statapath <- "/Applications/Stata/StataMP.app/Contents/MacOS/stata-mp"
+if(os == "Linux") statapath <- system("which stata-mp", intern = TRUE)
 opts_chunk$set(engine="stata", engine.path=statapath, comment="")
 ```
 

--- a/build_scripts/_convert_files.sh
+++ b/build_scripts/_convert_files.sh
@@ -4,13 +4,13 @@
 
 set -ev
 
-base_path="/Users/sworthin/Documents/IQSS/dss-workshops"
+base_path="$(dirname $(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd))"
 
 # DataScienceTools
 DataScienceTools_path="other_workshops/DataScienceTools"
 cd $base_path/$DataScienceTools_path
 jupytext --to R:bare DataScienceTools.Rmd
-sed -i "" '1,6d' DataScienceTools.R # delete lines 1-6
+sed -i '1,6d' DataScienceTools.R # delete lines 1-6
 jupytext --to notebook DataScienceTools.Rmd
 cd ..
 zip -r DataScienceTools.zip DataScienceTools -x "*.DS_Store"
@@ -19,7 +19,7 @@ zip -r DataScienceTools.zip DataScienceTools -x "*.DS_Store"
 Rintro_path="R/Rintro"
 cd $base_path/$Rintro_path
 jupytext --to R:bare Rintro.Rmd
-sed -i "" '1,6d' Rintro.R # delete lines 1-6
+sed -i '1,6d' Rintro.R # delete lines 1-6
 jupytext --to notebook Rintro.Rmd
 cd ..
 zip -r Rintro.zip Rintro -x "*.DS_Store"
@@ -28,7 +28,7 @@ zip -r Rintro.zip Rintro -x "*.DS_Store"
 Rmodels_path="R/Rmodels"
 cd $base_path/$Rmodels_path
 jupytext --to R:bare Rmodels.Rmd
-sed -i "" '1,6d' Rmodels.R # delete lines 1-6
+sed -i '1,6d' Rmodels.R # delete lines 1-6
 jupytext --to notebook Rmodels.Rmd
 cd ..
 zip -r Rmodels.zip Rmodels -x "*.DS_Store"
@@ -37,7 +37,7 @@ zip -r Rmodels.zip Rmodels -x "*.DS_Store"
 Rgraphics_path="R/Rgraphics"
 cd $base_path/$Rgraphics_path
 jupytext --to R:bare Rgraphics.Rmd
-sed -i "" '1,6d' Rgraphics.R # delete lines 1-6
+sed -i '1,6d' Rgraphics.R # delete lines 1-6
 jupytext --to notebook Rgraphics.Rmd
 cd ..
 zip -r Rgraphics.zip Rgraphics -x "*.DS_Store"
@@ -46,7 +46,7 @@ zip -r Rgraphics.zip Rgraphics -x "*.DS_Store"
 RDataWrangling_path="R/RDataWrangling"
 cd $base_path/$RDataWrangling_path
 jupytext --to R:bare RDataWrangling.Rmd
-sed -i "" '1,6d' RDataWrangling.R # delete lines 1-6
+sed -i '1,6d' RDataWrangling.R # delete lines 1-6
 jupytext --to notebook RDataWrangling.Rmd
 cd ..
 zip -r RDataWrangling.zip RDataWrangling -x "*.DS_Store"
@@ -55,7 +55,7 @@ zip -r RDataWrangling.zip RDataWrangling -x "*.DS_Store"
 PythonIntro_path="Python/PythonIntro"
 cd $base_path/$PythonIntro_path
 jupytext --to py:bare PythonIntro.Rmd
-sed -i "" '1,4d' PythonIntro.py # delete lines 1-4
+sed -i '1,4d' PythonIntro.py # delete lines 1-4
 jupytext --to notebook PythonIntro.Rmd
 cd ..
 zip -r PythonIntro.zip PythonIntro -x "*.DS_Store"
@@ -64,7 +64,7 @@ zip -r PythonIntro.zip PythonIntro -x "*.DS_Store"
 PythonWebScrape_path="Python/PythonWebScrape"
 cd $base_path/$PythonWebScrape_path
 jupytext --to py:bare PythonWebScrape.Rmd
-sed -i "" '1,4d' PythonWebScrape.py # delete lines 1-4
+sed -i '1,4d' PythonWebScrape.py # delete lines 1-4
 jupytext --to notebook PythonWebScrape.Rmd
 cd ..
 zip -r PythonWebScrape.zip PythonWebScrape -x "*.DS_Store"
@@ -74,8 +74,8 @@ StataIntro_path="Stata/StataIntro"
 cd $base_path/$StataIntro_path
 jupytext --to R:bare StataIntro.Rmd  # convert to R 'bare' format option
 mv StataIntro.R StataIntro.do  # change file suffix to .do
-sed -i "" 's/#/*/' StataIntro.do # convert # to *
-sed -i "" '1,7d' StataIntro.do # delete lines 1-7
+sed -i 's/#/*/' StataIntro.do # convert # to *
+sed -i '1,7d' StataIntro.do # delete lines 1-7
 # then change hash comments to astericks
 cd ..
 zip -r StataIntro.zip StataIntro -x "*.DS_Store"
@@ -85,8 +85,8 @@ StataDatMan_path="Stata/StataDatMan"
 cd $base_path/$StataDatMan_path
 jupytext --to R:bare StataDatMan.Rmd  # convert to R 'bare' format option
 mv StataDatMan.R StataDatMan.do  # change file suffix to .do
-sed -i "" 's/#/*/' StataDatMan.do # convert # to *
-sed -i "" '1,7d' StataDatMan.do # delete lines 1-7
+sed -i 's/#/*/' StataDatMan.do # convert # to *
+sed -i '1,7d' StataDatMan.do # delete lines 1-7
 # then change hash comments to astericks
 cd ..
 zip -r StataDatMan.zip StataDatMan -x "*.DS_Store"
@@ -96,8 +96,8 @@ StataModGraph_path="Stata/StataModGraph"
 cd $base_path/$StataModGraph_path
 jupytext --to R:bare StataModGraph.Rmd  # convert to R 'bare' format option
 mv StataModGraph.R StataModGraph.do  # change file suffix to .do
-sed -i "" 's/#/*/' StataModGraph.do # convert # to *
-sed -i "" '1,7d' StataModGraph.do # delete lines 1-7
+sed -i 's/#/*/' StataModGraph.do # convert # to *
+sed -i '1,7d' StataModGraph.do # delete lines 1-7
 # then change hash comments to astericks
 cd ..
 zip -r StataModGraph.zip StataModGraph -x "*.DS_Store"


### PR DESCRIPTION
The build scripts hard-coded the top-level workshop directly path as well as the (Mac-specific) Stata path. I adjusted these so that the build scripts work on Linux as well. 

I also had to remove extra `""` arguments from `sed` in order to get the build scripts working on my machine. I don't use `sed` much so I'm not sure what that argument might do in other `sed` implementations and I don't have a Mac to test it out on. Probably a good idea to test this change locally on a Mac before merging.